### PR TITLE
Fixed "No Btn" bug

### DIFF
--- a/Docking.cs
+++ b/Docking.cs
@@ -5,6 +5,9 @@ using UnityEngine.UI;
 
 public class Docking : MonoBehaviour {
 
+	//public GameObject dockCube;
+	//public Slider speedSlider;
+
 	//FIXME: This method does not work. Dunno why. Probs don't need it in the future anyway.
 	/*void onTriggerEnter(Collider other){
 		Debug.Log ("ENTERED the trigger...");
@@ -14,22 +17,25 @@ public class Docking : MonoBehaviour {
 	public Button parkBtn;
 
 	void Start(){
+		//dockCube = GameObject.Find ("Dock Cube");
+		//speedSlider = GameObject.Find ("Speed Slider").GetComponent<Slider> ();
+
 		// Autonomous driving stuff
-		parkBtn = GameObject.FindObjectOfType<Button>(); //GetComponent<Button> ();
+		parkBtn = parkBtn.GetComponent<Button> ();
 		parkBtn.enabled = false; //button is not interactable (for now)
 		parkBtn.gameObject.SetActive(false); //makes button disappear
 	}
 
 	// Displays parkBtn
 	void OnTriggerStay(Collider other){
-		//Debug.Log ("WITHIN trigger...");
+		Debug.Log ("WITHIN trigger...");
 		parkBtn.enabled = true; // Button is interactable (for now)
 		parkBtn.gameObject.SetActive(true); // Makes button appear
 	}
 
 	// Hides parkBtn
 	void OnTriggerExit(Collider other){
-		//Debug.Log ("EXITED the trigger...");
+		Debug.Log ("EXITED the trigger...");
 		parkBtn.enabled = false; // Button is not interactable (for now)
 		parkBtn.gameObject.SetActive(false); // Makes button disappear
 	}
@@ -37,6 +43,7 @@ public class Docking : MonoBehaviour {
 	public void onBtnClick(){
 		//set up auto-docking code here
 		Debug.Log ("PARKING BTN CLICKED");
+		//Debug.Log ("Speed: " + speedSlider.value);
+		//transform.Translate (dockCube.transform.position * speed * Time.deltaTime);
 	}
-
 }

--- a/InterfaceScript.cs
+++ b/InterfaceScript.cs
@@ -7,6 +7,8 @@ using UnityEngine.SceneManagement;
 //the script for all of the interface/display elements in the main scene (actual simulation environment)
 public class InterfaceScript : MonoBehaviour {
 
+	public Button parkBtn;
+
 	//canvases/menus
 	public Canvas mainInterface;
 	public Canvas quitMenu; 
@@ -41,7 +43,11 @@ public class InterfaceScript : MonoBehaviour {
 
 	// Use this for initialization
 	void Start () {
-		
+
+		parkBtn = parkBtn.GetComponent<Button> ();//GameObject.FindObjectOfType<Button>();
+		parkBtn.enabled = false; //button is not interactable (for now)
+		parkBtn.gameObject.SetActive(false); //makes button disappear
+
 		//canvases/menus
 		mainInterface = mainInterface.GetComponent<Canvas>();
 		quitMenu = quitMenu.GetComponent<Canvas> ();
@@ -161,7 +167,6 @@ public class InterfaceScript : MonoBehaviour {
 		mainInterface.enabled = true;
 		quitMenu.enabled = false;
 		settingsMenu.enabled = false;
-
 		exitBtn.enabled = true;
 		zoomSlider.enabled = true;
 		volumeSlider.enabled = true;

--- a/ObstacleDetection.cs
+++ b/ObstacleDetection.cs
@@ -12,7 +12,7 @@ public class ObstacleDetection : MonoBehaviour {
 	public Rigidbody rb; //for collisions and parking system in place
 
 	public GameObject Player;
-	public GameObject dock;
+	public GameObject trigger;
 	private GameObject theHitObject; //for obstacle detection
 
 	public GameObject[] deskObstacles; //for clearing obstacle warnings- desks
@@ -45,7 +45,7 @@ public class ObstacleDetection : MonoBehaviour {
 	// Use this for initialization
 	void Start () 
 	{
-		dock = GameObject.Find ("Trigger");
+		trigger = GameObject.Find ("Trigger");
 		//I tried setting up the slider like in InterfaceScript.cs, but it kept giving me the error messge about null...
 		speedSlider = GameObject.Find ("Speed Slider").GetComponent<Slider> ();
 
@@ -205,8 +205,8 @@ public class ObstacleDetection : MonoBehaviour {
 		}
 		//can still move forward if object in front is dock
 		else if(Input.GetKey (KeyCode.UpArrow) && (Physics.Raycast (transform.position, forward, out hit, detectionDistance) || Physics.Raycast (transform.position, diagonal1, out hit, detectionDistance) || Physics.Raycast (transform.position, diagonal4, out hit, detectionDistance))){
-			if(hit.collider.gameObject == dock){
-				//Debug.Log ("DOCK is HIT OBJECT");
+			if(hit.collider.gameObject == trigger){
+				//Debug.Log ("trigger is HIT OBJECT");
 				transform.Translate (Vector3.forward * speed * Time.deltaTime);
 			}
 		}
@@ -220,7 +220,7 @@ public class ObstacleDetection : MonoBehaviour {
 		}
 		//can still move backward if object in back is dock
 		else if(Input.GetKey (KeyCode.DownArrow) && (Physics.Raycast (transform.position, back, out hit, detectionDistance) || Physics.Raycast (transform.position, diagonal2, out hit, detectionDistance) || Physics.Raycast (transform.position, diagonal3, out hit, detectionDistance)) ){
-			if (hit.collider.gameObject == dock) {
+			if (hit.collider.gameObject == trigger) {
 				transform.Translate (-Vector3.forward * speed * Time.deltaTime);
 			}
 		}


### PR DESCRIPTION
When I implemented the parkBtn, the "No Btn" (when clicking to end the session) would not appear. Fixed it. "No Btn" appears and parkBtn does too (when in trigger area).